### PR TITLE
Bump version to 0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,27 @@
+## Change Log
+
+### 0.1.2 (2017/07/18 14:00 +09:00)
+- [#5](https://github.com/szyn/digdag-slack/pull/5) fix PluginClassLoader(metaspace) Leak (@maitani)
+- [0465956](https://github.com/szyn/digdag-slack/commit/0465956f34cfaf4882fe90ee16e9e4ccf184bdc8) change http client to okhttp (@maitani)
+- [#2](https://github.com/szyn/digdag-slack/pull/2) Reformat code (@szyn)
+- [f5703de](https://github.com/szyn/digdag-slack/commit/f5703de6613bb3bdd2758d6e4659d7e1d34f7826) Reformat code (@szyn)
+- [10a0d4f](https://github.com/szyn/digdag-slack/commit/10a0d4fb73a8cb2451f57a3e2a69c42bad0d0bea) Update README.md (@szyn)
+- [#1](https://github.com/szyn/digdag-slack/pull/1) Add channel parameter to sample (@grimrose)
+- [e2488e9](https://github.com/szyn/digdag-slack/commit/e2488e98c5aba567fc4d87fc0ab2699f63064ea2) Add channel parameter to sample (@grimrose)
+- [b40e883](https://github.com/szyn/digdag-slack/commit/b40e88391d7d18c108d4fe180bcb8dfae7434573) Update README.md (@szyn)
+- [51df993](https://github.com/szyn/digdag-slack/commit/51df993a7c23a2805d71a9c22e1ff0692350dce1) Update LICENSE (@szyn)
+- [7c6bc0f](https://github.com/szyn/digdag-slack/commit/7c6bc0fc2c342fccb17d3d4b635399ad245d2921) Update README.md (@szyn)
+- [f3b4e78](https://github.com/szyn/digdag-slack/commit/f3b4e78f5a3ca3ca15e73eaeec16441d963446aa) Update webhook_url :cry: (@szyn)
+
+### 0.1.1 (2017/04/14 23:13 +09:00)
+- [837d7f8](https://github.com/szyn/digdag-slack/commit/837d7f82b0c30cfe63cb8f6d3f6874471efb11b5) Update sample descripton (@szyn)
+- [83673d2](https://github.com/szyn/digdag-slack/commit/83673d2153c9d5d3af2eead0388633a1e4104ac7) Update sample workflow to use task_name (@szyn)
+- [1e421d6](https://github.com/szyn/digdag-slack/commit/1e421d6fdd8ca274adbf36cd4b6d500e561569bf) Update digdagVersion (@szyn)
+- [bae16f1](https://github.com/szyn/digdag-slack/commit/bae16f10e1790b7dfab9bd46cfb37f1808dd9091) Update sample workflow (@szyn)
+- [928fdd9](https://github.com/szyn/digdag-slack/commit/928fdd9c5d6fd8222757f6c5a54cc451fd1d2c8e) Fix LICENSE (@szyn)
+- [a7318f8](https://github.com/szyn/digdag-slack/commit/a7318f845a5f97033114663cc74a06339bd8e22c) Modify demo's imgs (@szyn)
+- [75993cd](https://github.com/szyn/digdag-slack/commit/75993cd6f749b40a3fe8fb050e7eda2a5caa71c4) Modify README (@szyn)
+- [955794a](https://github.com/szyn/digdag-slack/commit/955794a5c4eda25f6a0694ab8aa193b57c8176c5) Add sample imgs (@szyn)
+
+### 0.1.0 (2017/04/03 07:17 +09:00)
+- [b65ce71](https://github.com/szyn/digdag-slack/commit/b65ce718ff86b68e146ff5ee302a2ab52f6042a3) first commit (@szyn)

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Also, you can see expamle workflow at [sample](https://github.com/szyn/digdag-sl
       repositories:
         - https://jitpack.io
       dependencies:
-        - com.github.szyn:digdag-slack:0.1.1
+        - com.github.szyn:digdag-slack:0.1.2
     # Set Reqired params
     webhook_url: https://hooks.slack.com/services/XXX/XXX/XXX
     # Set Option params

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'maven-publish'
 apply plugin: 'idea'
 
 group = 'io.digdag.plugin'
-version = '0.1.1'
+version = '0.1.2'
 
 def digdagVersion = '0.9.12'
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ apply plugin: 'idea'
 group = 'io.digdag.plugin'
 version = '0.1.1'
 
-def digdagVersion = '0.9.9'
+def digdagVersion = '0.9.12'
 
 repositories {
     mavenLocal()

--- a/sample/slack.dig
+++ b/sample/slack.dig
@@ -4,8 +4,8 @@ _export:
       # - file://${repos}
       - https://jitpack.io
     dependencies:
-      # - io.digdag.plugin:digdag-slack:0.1.1
-      - com.github.szyn:digdag-slack:0.1.1
+      # - io.digdag.plugin:digdag-slack:0.1.2
+      - com.github.szyn:digdag-slack:0.1.2
   # Set Reqired params
   webhook_url: https://hooks.slack.com/services/XXXX/XXXXX/XXXXXXX
   # Set Option params


### PR DESCRIPTION
### 0.1.2 
- [#5](https://github.com/szyn/digdag-slack/pull/5) fix PluginClassLoader(metaspace) Leak (@maitani)
- [0465956](https://github.com/szyn/digdag-slack/commit/0465956f34cfaf4882fe90ee16e9e4ccf184bdc8) change http client to okhttp (@maitani)
- [#2](https://github.com/szyn/digdag-slack/pull/2) Reformat code (@szyn)
- [f5703de](https://github.com/szyn/digdag-slack/commit/f5703de6613bb3bdd2758d6e4659d7e1d34f7826) Reformat code (@szyn)
- [10a0d4f](https://github.com/szyn/digdag-slack/commit/10a0d4fb73a8cb2451f57a3e2a69c42bad0d0bea) Update README.md (@szyn)
- [#1](https://github.com/szyn/digdag-slack/pull/1) Add channel parameter to sample (@grimrose)
- [e2488e9](https://github.com/szyn/digdag-slack/commit/e2488e98c5aba567fc4d87fc0ab2699f63064ea2) Add channel parameter to sample (@grimrose)
- [b40e883](https://github.com/szyn/digdag-slack/commit/b40e88391d7d18c108d4fe180bcb8dfae7434573) Update README.md (@szyn)
- [51df993](https://github.com/szyn/digdag-slack/commit/51df993a7c23a2805d71a9c22e1ff0692350dce1) Update LICENSE (@szyn)
- [7c6bc0f](https://github.com/szyn/digdag-slack/commit/7c6bc0fc2c342fccb17d3d4b635399ad245d2921) Update README.md (@szyn)
- [f3b4e78](https://github.com/szyn/digdag-slack/commit/f3b4e78f5a3ca3ca15e73eaeec16441d963446aa) Update webhook_url :cry: (@szyn)