### PR TITLE
Using jackson-dataformat-yaml

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ configurations {
 
 dependencies {
     compile 'com.squareup.okhttp3:okhttp:3.8.1'
-    compile 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.9.1'
+    provided 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.9.1'
     provided 'io.digdag:digdag-spi:' + digdagVersion
     provided 'io.digdag:digdag-plugin-utils:' + digdagVersion  // this should be 'compile' instead of 'provided' once digdag 0.8.18 is released to one of the built-in repositories (maven central or jcenter)
 }

--- a/build.gradle
+++ b/build.gradle
@@ -23,8 +23,7 @@ configurations {
 
 dependencies {
     compile 'com.squareup.okhttp3:okhttp:3.8.1'
-    compile 'org.yaml:snakeyaml:1.18'
-    compile 'org.json:json:20160810'
+    compile 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.9.1'
     provided 'io.digdag:digdag-spi:' + digdagVersion
     provided 'io.digdag:digdag-plugin-utils:' + digdagVersion  // this should be 'compile' instead of 'provided' once digdag 0.8.18 is released to one of the built-in repositories (maven central or jcenter)
 }

--- a/src/main/java/io/digdag/plugin/slack/SlackPayload.java
+++ b/src/main/java/io/digdag/plugin/slack/SlackPayload.java
@@ -1,18 +1,32 @@
 package io.digdag.plugin.slack;
 
-import org.json.JSONObject;
-import org.yaml.snakeyaml.Yaml;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 
-import java.util.Map;
+import java.io.IOException;
 
-public class SlackPayload
+class SlackPayload
 {
-    public static String convertToJson(String yamlString)
+    static String convertToJson(String yaml)
     {
-        Yaml yaml = new Yaml();
-        Map<String, Object> map = (Map<String, Object>) yaml.load(yamlString);
+        ObjectMapper yamlReader = new ObjectMapper(new YAMLFactory());
+        Object obj = null;
+        try {
+            obj = yamlReader.readValue(yaml, Object.class);
+        }
+        catch (IOException e) {
+            e.printStackTrace();
+        }
 
-        JSONObject jsonObject = new JSONObject(map);
-        return jsonObject.toString();
+        String result = null;
+        ObjectMapper jsonWriter = new ObjectMapper();
+        try {
+            result = jsonWriter.writeValueAsString(obj);
+        }
+        catch (JsonProcessingException e) {
+            e.printStackTrace();
+        }
+        return result;
     }
 }

--- a/src/main/java/io/digdag/plugin/slack/SlackPayload.java
+++ b/src/main/java/io/digdag/plugin/slack/SlackPayload.java
@@ -8,12 +8,13 @@ import java.io.IOException;
 
 class SlackPayload
 {
-    static String convertToJson(String yaml)
+    static String convertToJson(String yamlString)
     {
         ObjectMapper yamlReader = new ObjectMapper(new YAMLFactory());
+
         Object obj = null;
         try {
-            obj = yamlReader.readValue(yaml, Object.class);
+            obj = yamlReader.readValue(yamlString, Object.class);
         }
         catch (IOException e) {
             e.printStackTrace();


### PR DESCRIPTION
Update to use jackson-dataformat-yaml instead of json and snakeyaml.