### PR TITLE
Release 0.1.3

### DIFF
--- a/.circleci/test.dig
+++ b/.circleci/test.dig
@@ -3,7 +3,7 @@ _export:
     repositories:
        - file://${repos}
     dependencies:
-       - io.digdag.plugin:digdag-slack:${version}-SNAPSHOT
+       - io.digdag.plugin:digdag-slack:${version}
   webhook_url: https://hooks.slack.com/services/${token}
   workflow_name: slack
   ENV: test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 ## Change Log
 
-### 0.1.2 (2017/07/18 14:02 +09:00)
+### 0.1.3 (2017/10/02 15:43 +00:00)
+- [#10](https://github.com/szyn/digdag-slack/pull/10) Bump digdagVersion to 0.9.17 (#10) (@szyn)
+- [#9](https://github.com/szyn/digdag-slack/pull/9) Using jackson dataformat yaml (#9) (@szyn)
+- [#8](https://github.com/szyn/digdag-slack/pull/8) Add params validation (#8) (@szyn)
+- [#7](https://github.com/szyn/digdag-slack/pull/7) Setup CircleCi (#7) (@szyn)
+
+### 0.1.2 (2017/07/18 05:02 +00:00)
 - [#6](https://github.com/szyn/digdag-slack/pull/6) Bump version to 0.1.2 (@szyn)
 - [#5](https://github.com/szyn/digdag-slack/pull/5) fix PluginClassLoader(metaspace) Leak (@maitani)
 - [#2](https://github.com/szyn/digdag-slack/pull/2) Reformat code (@szyn)

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'maven-publish'
 apply plugin: 'idea'
 
 group = 'io.digdag.plugin'
-version = '0.1.3-SNAPSHOT'
+version = '0.1.3'
 
 def digdagVersion = '0.9.17'
 


### PR DESCRIPTION
### 0.1.3 (2017/10/02 15:43 +00:00)
- [#10](https://github.com/szyn/digdag-slack/pull/10) Bump digdagVersion to 0.9.17 (#10) (@szyn)
- [#9](https://github.com/szyn/digdag-slack/pull/9) Using jackson dataformat yaml (#9) (@szyn)
- [#8](https://github.com/szyn/digdag-slack/pull/8) Add params validation (#8) (@szyn)
- [#7](https://github.com/szyn/digdag-slack/pull/7) Setup CircleCi (#7) (@szyn)