### PR TITLE
Fix issue #17

### DIFF
--- a/src/main/java/io/digdag/plugin/slack/SlackOperatorFactory.java
+++ b/src/main/java/io/digdag/plugin/slack/SlackOperatorFactory.java
@@ -86,7 +86,8 @@ public class SlackOperatorFactory
 
             try (Response response = call.execute()) {
                 if (!response.isSuccessful()) {
-                    throw new IOException("posting to slack failed");
+                    String message = "status: " + response.code() + ", message: " + response.body().string();
+                    throw new IOException(message);
                 }
             }
             catch (IOException e) {


### PR DESCRIPTION
To fix https://github.com/szyn/digdag-slack/issues/17 issue.

I change to logic to output http response from https://hook.slack.com .
cf. https://api.slack.com/incoming-webhooks#handling_errors

e.g. When the channel associated with your request doesn't exist

before: "posting to slack failed" is output
```console
2017-12-15 07:08:17 +0000: Digdag v0.9.21
2017-12-15 07:08:21 +0000 [WARN] (main): Reusing the last session time 2017-12-01T00:00:00+00:00.
2017-12-15 07:08:21 +0000 [INFO] (main): Using session /root/digdag-slack/.circleci/.digdag/status/20171201T000000+0000.
2017-12-15 07:08:21 +0000 [INFO] (main): Starting a new session project id=1 workflow name=success session_time=2017-12-01T00:00:00+00:00
2017-12-15 07:08:25 +0000 [INFO] (0016@[0:default]+success+task): slack>: templates/valid.yml
java.io.IOException: posting to slack failed
	at io.digdag.plugin.slack.SlackOperatorFactory$SlackOperator.postToSlack(SlackOperatorFactory.java:91)
	at io.digdag.plugin.slack.SlackOperatorFactory$SlackOperator.runTask(SlackOperatorFactory.java:69)
	at io.digdag.util.BaseOperator.run(BaseOperator.java:35)
	at io.digdag.core.agent.OperatorManager.callExecutor(OperatorManager.java:312)
	at io.digdag.cli.Run$OperatorManagerWithSkip.callExecutor(Run.java:694)
	at io.digdag.core.agent.OperatorManager.runWithWorkspace(OperatorManager.java:254)
	at io.digdag.core.agent.OperatorManager.lambda$runWithHeartbeat$2(OperatorManager.java:137)
	at io.digdag.core.agent.LocalWorkspaceManager.withExtractedArchive(LocalWorkspaceManager.java:25)
	at io.digdag.core.agent.OperatorManager.runWithHeartbeat(OperatorManager.java:135)
	at io.digdag.core.agent.OperatorManager.run(OperatorManager.java:119)
	at io.digdag.cli.Run$OperatorManagerWithSkip.run(Run.java:676)
	at io.digdag.core.agent.MultiThreadAgent.lambda$null$0(MultiThreadAgent.java:127)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
Success. Task state is saved at /root/digdag-slack/.circleci/.digdag/status/20171201T000000+0000 directory.
  * Use --session <daily | hourly | "yyyy-MM-dd[ HH:mm:ss]"> to not reuse the last session time.
  * Use --rerun, --start +NAME, or --goal +NAME argument to rerun skipped tasks.
```

after: A http response from https://hook.slack.com is output
```console
2017-12-15 07:10:35 +0000: Digdag v0.9.21
2017-12-15 07:10:39 +0000 [WARN] (main): Reusing the last session time 2017-12-01T00:00:00+00:00.
2017-12-15 07:10:39 +0000 [INFO] (main): Using session /root/digdag-slack/.circleci/.digdag/status/20171201T000000+0000.
2017-12-15 07:10:39 +0000 [INFO] (main): Starting a new session project id=1 workflow name=success session_time=2017-12-01T00:00:00+00:00
2017-12-15 07:10:42 +0000 [INFO] (0016@[0:default]+success+task): slack>: templates/valid.yml
java.io.IOException: status: 404, message: channel_not_found
	at io.digdag.plugin.slack.SlackOperatorFactory$SlackOperator.postToSlack(SlackOperatorFactory.java:90)
	at io.digdag.plugin.slack.SlackOperatorFactory$SlackOperator.runTask(SlackOperatorFactory.java:69)
	at io.digdag.util.BaseOperator.run(BaseOperator.java:35)
	at io.digdag.core.agent.OperatorManager.callExecutor(OperatorManager.java:312)
	at io.digdag.cli.Run$OperatorManagerWithSkip.callExecutor(Run.java:694)
	at io.digdag.core.agent.OperatorManager.runWithWorkspace(OperatorManager.java:254)
	at io.digdag.core.agent.OperatorManager.lambda$runWithHeartbeat$2(OperatorManager.java:137)
	at io.digdag.core.agent.LocalWorkspaceManager.withExtractedArchive(LocalWorkspaceManager.java:25)
	at io.digdag.core.agent.OperatorManager.runWithHeartbeat(OperatorManager.java:135)
	at io.digdag.core.agent.OperatorManager.run(OperatorManager.java:119)
	at io.digdag.cli.Run$OperatorManagerWithSkip.run(Run.java:676)
	at io.digdag.core.agent.MultiThreadAgent.lambda$null$0(MultiThreadAgent.java:127)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
Success. Task state is saved at /root/digdag-slack/.circleci/.digdag/status/20171201T000000+0000 directory.
  * Use --session <daily | hourly | "yyyy-MM-dd[ HH:mm:ss]"> to not reuse the last session time.
  * Use --rerun, --start +NAME, or --goal +NAME argument to rerun skipped tasks.
```