### PR TITLE
add retry to postToSlack

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,9 @@
-version: 2
+version: 2.1
 jobs:
   build:
     working_directory: ~/digdag-slack
     docker:
-      - image: openjdk:8u141-jdk
+      - image: cimg/openjdk:8.0.402
         environment:
          TERM: dumb
 
@@ -14,8 +14,8 @@ jobs:
       - run:
           name: Install digdag
           command: |
-            curl -o /bin/digdag --create-dirs -L "https://dl.digdag.io/digdag-latest"
-            chmod +x /bin/digdag
+            sudo curl -o /bin/digdag --create-dirs -L "https://dl.digdag.io/digdag-latest"
+            sudo chmod +x /bin/digdag
 
       - run:
           name: Testing post to slack

--- a/.circleci/success.dig
+++ b/.circleci/success.dig
@@ -3,8 +3,4 @@ _export:
   webhook_url: https://hooks.slack.com/services/${token}
 
 +task:
-  _retry:
-    limit: 3
-    interval: 1
-    interval_type: exponential
   slack>: templates/valid.yml

--- a/.circleci/success.dig
+++ b/.circleci/success.dig
@@ -3,4 +3,8 @@ _export:
   webhook_url: https://hooks.slack.com/services/${token}
 
 +task:
+  _retry:
+    limit: 3
+    interval: 1
+    interval_type: exponential
   slack>: templates/valid.yml

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ apply plugin: 'idea'
 group = 'io.digdag.plugin'
 version = '0.1.5-SNAPSHOT'
 
-def digdagVersion = '0.9.17'
+def digdagVersion = '0.10.5.1'
 
 repositories {
     mavenLocal()

--- a/src/main/java/io/digdag/plugin/slack/SlackOperatorFactory.java
+++ b/src/main/java/io/digdag/plugin/slack/SlackOperatorFactory.java
@@ -13,16 +13,13 @@ import io.digdag.util.UserSecretTemplate;
 import okhttp3.Call;
 import okhttp3.FormBody;
 import okhttp3.Interceptor;
-import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.Response;
-import okhttp3.ResponseBody;
 
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.logging.Logger;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
@@ -122,13 +119,10 @@ public class SlackOperatorFactory
         public Response intercept(Chain chain) throws IOException
         {
             Request request = chain.request();
-            // Response response = chain.proceed(request);
-            Response response = new Response.Builder().code(503).message("503 Service Unavailable").body(ResponseBody.create(MediaType.parse("application/json; charset=utf-8"), "{}")).protocol(okhttp3.Protocol.HTTP_1_1).request(request).build();
+            Response response = chain.proceed(request);
             int retryCount = 0;
-            Logger logger = Logger.getLogger(RetryInterceptor.class.getName());
             while (!response.isSuccessful() && retryCount < MAX_RETRY_COUNT && Arrays.asList(retryHttpStatus).contains(response.code())) {
                 retryCount++;
-                logger.info("Retry count: " + retryCount);
     
                 response.close();
                 try {
@@ -137,8 +131,7 @@ public class SlackOperatorFactory
                     e.printStackTrace();
                 }
                 // retry request
-                // response = chain.proceed(request);
-                response = new Response.Builder().code(503).message("503 Service Unavailable").body(ResponseBody.create(MediaType.parse("application/json; charset=utf-8"), "{}")).protocol(okhttp3.Protocol.HTTP_1_1).request(request).build();
+                response = chain.proceed(request);
             }
             return response;
         }

--- a/src/main/java/io/digdag/plugin/slack/SlackOperatorFactory.java
+++ b/src/main/java/io/digdag/plugin/slack/SlackOperatorFactory.java
@@ -13,13 +13,16 @@ import io.digdag.util.UserSecretTemplate;
 import okhttp3.Call;
 import okhttp3.FormBody;
 import okhttp3.Interceptor;
+import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.Response;
+import okhttp3.ResponseBody;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.logging.Logger;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
@@ -119,10 +122,13 @@ public class SlackOperatorFactory
         public Response intercept(Chain chain) throws IOException
         {
             Request request = chain.request();
-            Response response = chain.proceed(request);
+            // Response response = chain.proceed(request);
+            Response response = new Response.Builder().code(503).message("503 Service Unavailable").body(ResponseBody.create(MediaType.parse("application/json; charset=utf-8"), "{}")).protocol(okhttp3.Protocol.HTTP_1_1).request(request).build();
             int retryCount = 0;
+            Logger logger = Logger.getLogger(RetryInterceptor.class.getName());
             while (!response.isSuccessful() && retryCount < MAX_RETRY_COUNT && Arrays.asList(retryHttpStatus).contains(response.code())) {
                 retryCount++;
+                logger.info("Retry count: " + retryCount);
     
                 response.close();
                 try {
@@ -131,7 +137,8 @@ public class SlackOperatorFactory
                     e.printStackTrace();
                 }
                 // retry request
-                response = chain.proceed(request);
+                // response = chain.proceed(request);
+                response = new Response.Builder().code(503).message("503 Service Unavailable").body(ResponseBody.create(MediaType.parse("application/json; charset=utf-8"), "{}")).protocol(okhttp3.Protocol.HTTP_1_1).request(request).build();
             }
             return response;
         }


### PR DESCRIPTION
## issue
In rare cases,  429 or 503 errors occur and posting to Slack is failed, but the `slack>:` task succeeds.
Error messages as below.
```
java.io.IOException: status: 429, message: {"retry_after":1,"ok":false,"error":"rate_limited"}
```

```
java.io.IOException: status: 503, message:
...
(omitted)
...
503 Service Unavailable
 
The server is temporarily unable to service your request due to maintenance downtime or capacity problems. Please try again later.
```
I want to retry when responce code is retryable.
Moreover I want to make slack task failed if posting to Slack is failed.

## modification
### how to retry
According to [the official okhttp document](https://square.github.io/okhttp/features/interceptors/#interceptors) , Interceptors are explained as bellow.
> Interceptors are a powerful mechanism that can monitor, rewrite, and retry calls.

> Application interceptors
> Permitted to short-circuit and not call Chain.proceed().

I created Interceptor class for retrying, and registered it by calling addInterceptor() on OkHttpClient.Builder.

### test error
commit: https://github.com/szyn/digdag-slack/pull/25/commits/0ba2663ec0dbd85ee7a8468bd7ecd824da7ba785
testing post to slack(circle ci): https://app.circleci.com/pipelines/github/szyn/digdag-slack/43/workflows/9c070197-d48b-4a37-a3be-7e8c37da8d5c/jobs/92

I checked to failed `slack>:` task and retrying post to slack when posting to slack was failed.
Also, you can control a setting of retry by using `_error`parameter.

<details><summary>Log</summary>

```
2024-02-22 10:39:35 +0000 [INFO] (0015@[0:default:1:1]+success+task): slack>: templates/valid.yml
Feb 22, 2024 10:39:36 AM io.digdag.plugin.slack.SlackOperatorFactory$RetryInterceptor intercept
INFO: Retry count: 1
Feb 22, 2024 10:39:38 AM io.digdag.plugin.slack.SlackOperatorFactory$RetryInterceptor intercept
INFO: Retry count: 2
Feb 22, 2024 10:39:42 AM io.digdag.plugin.slack.SlackOperatorFactory$RetryInterceptor intercept
INFO: Retry count: 3
Feb 22, 2024 10:39:50 AM io.digdag.plugin.slack.SlackOperatorFactory$RetryInterceptor intercept
INFO: Retry count: 4
Feb 22, 2024 10:40:06 AM io.digdag.plugin.slack.SlackOperatorFactory$RetryInterceptor intercept
INFO: Retry count: 5
2024-02-22 10:40:38 +0000 [ERROR] (0015@[0:default:1:1]+success+task): Task failed, retrying
io.digdag.spi.TaskExecutionException: java.lang.RuntimeException: Failed to send to Slack. status: 503, message: {}
        at io.digdag.spi.TaskExecutionException.ofNextPollingWithCause(TaskExecutionException.java:85)
        at io.digdag.util.BaseOperator.run(BaseOperator.java:56)
        at io.digdag.core.agent.OperatorManager.callExecutor(OperatorManager.java:399)
        at io.digdag.cli.Run$OperatorManagerWithSkip.callExecutor(Run.java:709)
        at io.digdag.core.agent.OperatorManager.runWithWorkspace(OperatorManager.java:308)
        at io.digdag.core.agent.OperatorManager.lambda$runWithHeartbeat$2(OperatorManager.java:152)
        at io.digdag.core.agent.LocalWorkspaceManager.withExtractedArchive(LocalWorkspaceManager.java:25)
        at io.digdag.core.agent.OperatorManager.runWithHeartbeat(OperatorManager.java:150)
        at io.digdag.core.agent.OperatorManager.run(OperatorManager.java:133)
        at io.digdag.cli.Run$OperatorManagerWithSkip.run(Run.java:691)
        at io.digdag.core.agent.MultiThreadAgent.lambda$run$0(MultiThreadAgent.java:132)
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
        at java.util.concurrent.FutureTask.run(FutureTask.java:266)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:750)
Caused by: java.lang.RuntimeException: Failed to send to Slack. status: 503, message: {}
        at io.digdag.plugin.slack.SlackOperatorFactory$SlackOperator.postToSlack(SlackOperatorFactory.java:102)
        at io.digdag.plugin.slack.SlackOperatorFactory$SlackOperator.runTask(SlackOperatorFactory.java:77)
        at io.digdag.util.BaseOperator.run(BaseOperator.java:35)
        ... 14 common frames omitted
Caused by: java.io.IOException: status: 503, message: {}
        at io.digdag.plugin.slack.SlackOperatorFactory$SlackOperator.postToSlack(SlackOperatorFactory.java:98)
        ... 16 common frames omitted
Feb 22, 2024 10:40:40 AM io.digdag.plugin.slack.SlackOperatorFactory$RetryInterceptor intercept
INFO: Retry count: 1
Feb 22, 2024 10:40:42 AM io.digdag.plugin.slack.SlackOperatorFactory$RetryInterceptor intercept
INFO: Retry count: 2
Feb 22, 2024 10:40:46 AM io.digdag.plugin.slack.SlackOperatorFactory$RetryInterceptor intercept
INFO: Retry count: 3
Feb 22, 2024 10:40:54 AM io.digdag.plugin.slack.SlackOperatorFactory$RetryInterceptor intercept
INFO: Retry count: 4
Feb 22, 2024 10:41:10 AM io.digdag.plugin.slack.SlackOperatorFactory$RetryInterceptor intercept
INFO: Retry count: 5
2024-02-22 10:41:42 +0000 [ERROR] (0015@[0:default:1:1]+success+task): Task failed, retrying
io.digdag.spi.TaskExecutionException: java.lang.RuntimeException: Failed to send to Slack. status: 503, message: {}
        at io.digdag.spi.TaskExecutionException.ofNextPollingWithCause(TaskExecutionException.java:85)
        at io.digdag.util.BaseOperator.run(BaseOperator.java:56)
        at io.digdag.core.agent.OperatorManager.callExecutor(OperatorManager.java:399)
        at io.digdag.cli.Run$OperatorManagerWithSkip.callExecutor(Run.java:709)
        at io.digdag.core.agent.OperatorManager.runWithWorkspace(OperatorManager.java:308)
        at io.digdag.core.agent.OperatorManager.lambda$runWithHeartbeat$2(OperatorManager.java:152)
        at io.digdag.core.agent.LocalWorkspaceManager.withExtractedArchive(LocalWorkspaceManager.java:25)
        at io.digdag.core.agent.OperatorManager.runWithHeartbeat(OperatorManager.java:150)
        at io.digdag.core.agent.OperatorManager.run(OperatorManager.java:133)
        at io.digdag.cli.Run$OperatorManagerWithSkip.run(Run.java:691)
        at io.digdag.core.agent.MultiThreadAgent.lambda$run$0(MultiThreadAgent.java:132)
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
        at java.util.concurrent.FutureTask.run(FutureTask.java:266)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:750)
Caused by: java.lang.RuntimeException: Failed to send to Slack. status: 503, message: {}
        at io.digdag.plugin.slack.SlackOperatorFactory$SlackOperator.postToSlack(SlackOperatorFactory.java:102)
        at io.digdag.plugin.slack.SlackOperatorFactory$SlackOperator.runTask(SlackOperatorFactory.java:77)
        at io.digdag.util.BaseOperator.run(BaseOperator.java:35)
        ... 14 common frames omitted
Caused by: java.io.IOException: status: 503, message: {}
        at io.digdag.plugin.slack.SlackOperatorFactory$SlackOperator.postToSlack(SlackOperatorFactory.java:98)
        ... 16 common frames omitted
Feb 22, 2024 10:41:45 AM io.digdag.plugin.slack.SlackOperatorFactory$RetryInterceptor intercept
INFO: Retry count: 1
Feb 22, 2024 10:41:47 AM io.digdag.plugin.slack.SlackOperatorFactory$RetryInterceptor intercept
INFO: Retry count: 2
Feb 22, 2024 10:41:51 AM io.digdag.plugin.slack.SlackOperatorFactory$RetryInterceptor intercept
INFO: Retry count: 3
Feb 22, 2024 10:41:59 AM io.digdag.plugin.slack.SlackOperatorFactory$RetryInterceptor intercept
INFO: Retry count: 4
Feb 22, 2024 10:42:15 AM io.digdag.plugin.slack.SlackOperatorFactory$RetryInterceptor intercept
INFO: Retry count: 5
2024-02-22 10:42:47 +0000 [ERROR] (0015@[0:default:1:1]+success+task): Task failed, retrying
io.digdag.spi.TaskExecutionException: java.lang.RuntimeException: Failed to send to Slack. status: 503, message: {}
        at io.digdag.spi.TaskExecutionException.ofNextPollingWithCause(TaskExecutionException.java:85)
        at io.digdag.util.BaseOperator.run(BaseOperator.java:56)
        at io.digdag.core.agent.OperatorManager.callExecutor(OperatorManager.java:399)
        at io.digdag.cli.Run$OperatorManagerWithSkip.callExecutor(Run.java:709)
        at io.digdag.core.agent.OperatorManager.runWithWorkspace(OperatorManager.java:308)
        at io.digdag.core.agent.OperatorManager.lambda$runWithHeartbeat$2(OperatorManager.java:152)
        at io.digdag.core.agent.LocalWorkspaceManager.withExtractedArchive(LocalWorkspaceManager.java:25)
        at io.digdag.core.agent.OperatorManager.runWithHeartbeat(OperatorManager.java:150)
        at io.digdag.core.agent.OperatorManager.run(OperatorManager.java:133)
        at io.digdag.cli.Run$OperatorManagerWithSkip.run(Run.java:691)
        at io.digdag.core.agent.MultiThreadAgent.lambda$run$0(MultiThreadAgent.java:132)
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
        at java.util.concurrent.FutureTask.run(FutureTask.java:266)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:750)
Caused by: java.lang.RuntimeException: Failed to send to Slack. status: 503, message: {}
        at io.digdag.plugin.slack.SlackOperatorFactory$SlackOperator.postToSlack(SlackOperatorFactory.java:102)
        at io.digdag.plugin.slack.SlackOperatorFactory$SlackOperator.runTask(SlackOperatorFactory.java:77)
        at io.digdag.util.BaseOperator.run(BaseOperator.java:35)
        ... 14 common frames omitted
Caused by: java.io.IOException: status: 503, message: {}
        at io.digdag.plugin.slack.SlackOperatorFactory$SlackOperator.postToSlack(SlackOperatorFactory.java:98)
        ... 16 common frames omitted
Feb 22, 2024 10:42:54 AM io.digdag.plugin.slack.SlackOperatorFactory$RetryInterceptor intercept
INFO: Retry count: 1
Feb 22, 2024 10:42:56 AM io.digdag.plugin.slack.SlackOperatorFactory$RetryInterceptor intercept
INFO: Retry count: 2
Feb 22, 2024 10:43:00 AM io.digdag.plugin.slack.SlackOperatorFactory$RetryInterceptor intercept
INFO: Retry count: 3
Feb 22, 2024 10:43:08 AM io.digdag.plugin.slack.SlackOperatorFactory$RetryInterceptor intercept
INFO: Retry count: 4
Feb 22, 2024 10:43:24 AM io.digdag.plugin.slack.SlackOperatorFactory$RetryInterceptor intercept
INFO: Retry count: 5
2024-02-22 10:43:56 +0000 [ERROR] (0015@[0:default:1:1]+success+task): Task failed with unexpected error: Failed to send to Slack. status: 503, message: {}
java.lang.RuntimeException: Failed to send to Slack. status: 503, message: {}
        at io.digdag.plugin.slack.SlackOperatorFactory$SlackOperator.postToSlack(SlackOperatorFactory.java:102)
        at io.digdag.plugin.slack.SlackOperatorFactory$SlackOperator.runTask(SlackOperatorFactory.java:77)
        at io.digdag.util.BaseOperator.run(BaseOperator.java:35)
        at io.digdag.core.agent.OperatorManager.callExecutor(OperatorManager.java:399)
        at io.digdag.cli.Run$OperatorManagerWithSkip.callExecutor(Run.java:709)
        at io.digdag.core.agent.OperatorManager.runWithWorkspace(OperatorManager.java:308)
        at io.digdag.core.agent.OperatorManager.lambda$runWithHeartbeat$2(OperatorManager.java:152)
        at io.digdag.core.agent.LocalWorkspaceManager.withExtractedArchive(LocalWorkspaceManager.java:25)
        at io.digdag.core.agent.OperatorManager.runWithHeartbeat(OperatorManager.java:150)
        at io.digdag.core.agent.OperatorManager.run(OperatorManager.java:133)
        at io.digdag.cli.Run$OperatorManagerWithSkip.run(Run.java:691)
        at io.digdag.core.agent.MultiThreadAgent.lambda$run$0(MultiThreadAgent.java:132)
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
        at java.util.concurrent.FutureTask.run(FutureTask.java:266)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:750)
Caused by: java.io.IOException: status: 503, message: {}
        at io.digdag.plugin.slack.SlackOperatorFactory$SlackOperator.postToSlack(SlackOperatorFactory.java:98)
        ... 16 common frames omitted
2024-02-22 10:43:57 +0000 [INFO] (0015@[0:default:1:1]+success^failure-alert): type: notify
error: 
  * +success+task:
    Failed to send to Slack. status: 503, message: {} (runtime)
```

</details> 

## other
### cicle ci
openjdk:8u141-jdk was added Let's Encrypt certificates ( https://www.java.com/download/help/release_changes.html ).
However, that CA had already expired, so an error occurs as below ( https://letsencrypt.org/docs/dst-root-ca-x3-expiration-september-2021/)
```
curl performs SSL certificate verification by default, using a "bundle"
 of Certificate Authority (CA) public keys (CA certs). If the default
 bundle file isn't adequate, you can specify an alternate file
 using the --cacert option.
If this HTTPS server uses a certificate signed by a CA represented in
 the bundle, the certificate verification probably failed due to a
 problem with the certificate (it might be expired, or the name might
 not match the domain name in the URL).
If you'd like to turn off curl's verification of the certificate, use
 the -k (or --insecure) option.
```
I modified to use the latest cimg/open-jdk8 instead of openjdk:8u141-jdk.
